### PR TITLE
Fixed github button reference link

### DIFF
--- a/index.html
+++ b/index.html
@@ -514,7 +514,7 @@
               <a href="#" aria-label="Instagram"
                 ><i class="fab fa-instagram"></i
               ></a>
-              <a href="#" aria-label="GitHub"><i class="fab fa-github"></i></a>
+              <a href="https://github.com/Sandali3000/Botanica" aria-label="GitHub"><i class="fab fa-github"></i></a>
             </div>
           </div>
 


### PR DESCRIPTION
### Issue Solved

There was a social link button of GitHub in the footer section which was not working as expected.

---

**Earlier**

On clicking the GitHub button, it was taking us to the homepage of the website.

---

**Now**

On clicking the GitHub button, it will now take us to the GitHub [repo](https://github.com/Sandali3000/Botanica).

Solves issue #70 .
