### PR TITLE
docs: Add contributors section with profile pictures

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,20 @@ We welcome contributions to Botanica! If you'd like to help improve the project,
 
 Thank you for helping to make Botanica better for all plant enthusiasts!
 
+
+## 👥 Contributors
+
+Thanks to these wonderful people who have contributed to Botanica:
+
+<table>
+  <tr>
+    <td align="center"><a href="https://github.com/Sandali3000"><img src="https://github.com/Sandali3000.png?size=100" width="100px;" alt="Sandali3000"/><br /><sub><b>Sandali3000</b></sub></a><br />📖 💻 🎨</td>
+    <td align="center"><a href="https://github.com/kaifansariw"><img src="https://github.com/kaifansariw.png?size=100" width="100px;" alt="kaifansariw"/><br /><sub><b>kaifansariw</b></sub></a><br />💻 🐛</td>
+  </tr>
+</table>
+
+**Legend:**  
+📖 Documentation | 💻 Code | 🎨 Design | 🐛 Bug fixes | ✅ Tests
+
+---
 [🔝 Back to Top](#-botanica----plant-collection-app)


### PR DESCRIPTION
Added a new Contributors section to the README with profile pictures and contribution types for Sandali3000 and kaifansariw.

Includes:
- Profile pictures from GitHub
- Contribution icons (docs, code, design, bug fixes)
- Legend explaining contribution types

Fixes #102
Submitted for Hacktoberfest 2025.